### PR TITLE
Tiling for cholesky solve instead of inverse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Here we vary the number of vertices that are used for the cantilever mesh. Since
 ```
 python examples/benchmark_vbd_solve.py
 ```
-We do 100 timesteps of 1ms, sampled 3 times for mean and standard deviation in the runtime plot (standard deviation is too small to be visible), but multiply this by 10 for how long a simulated second would have taken.
+We do 300 timesteps of 1ms, sampled 3 times for mean and standard deviation in the runtime plot (standard deviation is too small to be visible), but multiply this by 10 for how long a simulated second would have taken.
 
 <p align="left">
     <img src="asset/imgs/benchmark_runtime_vbd.png" width="400px" align="top"/>

--- a/examples/benchmark_tolerance.py
+++ b/examples/benchmark_tolerance.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
             simulation.reset()
             tip_positions.clear()
             for _ in range(nt):
+                print(f"Timestep {_+1}/{nt} for dx_tol={dx_tol}", end="\r")
                 solution = simulation.step(dt)
                 tip_positions.append(solution.numpy()[simulation.tip_idx].mean(axis=0))
 

--- a/examples/benchmark_vbd_parallel.py
+++ b/examples/benchmark_vbd_parallel.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
         def vbd_solve (simulation, nt, dt):
             simulation.reset()
             for _ in range(nt):
+                print(f"Timestep {_+1}/{nt} for NSIM={nsim}", end="\r")
                 simulation.step(dt)
 
         times = benchmark_functions([vbd_solve], sim, n_timesteps, timestep, num_samples=n_samples)

--- a/examples/benchmark_vbd_solver.py
+++ b/examples/benchmark_vbd_solver.py
@@ -42,20 +42,21 @@ if __name__ == "__main__":
             nx=(10*rf, 3*rf, 3*rf),
             dx=(dx, dx, dx),
             density=1070, youngs_modulus=150e3, poissons_ratio=0.45,
-            dx_tol=1e-9, max_iter=3000, device="cuda"
+            dx_tol=1e-6, max_iter=3000, device="cuda"
         )
         metrics["num_vertices"].append(sim.initial_positions.shape[0])
         metrics["num_elements"].append(sim.elements.shape[0])
 
         ### Benchmark solver time
         timestep = 1e-3
-        n_timesteps = 300
+        n_timesteps = 100
         
         tip_positions = []
         def vbd_solve (simulation, nt, dt):
             simulation.reset()
             tip_positions.clear()
             for _ in range(nt):
+                print(f"Timestep {_+1}/{nt} for RF={rf}", end="\r")
                 solution = simulation.step(dt)
                 tip_positions.append(solution.numpy()[simulation.tip_idx].mean(axis=0))
 

--- a/examples/benchmark_vbd_solver.py
+++ b/examples/benchmark_vbd_solver.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
         ### Benchmark solver time
         timestep = 1e-3
-        n_timesteps = 100
+        n_timesteps = 300
         
         tip_positions = []
         def vbd_solve (simulation, nt, dt):

--- a/src/_utils.py
+++ b/src/_utils.py
@@ -3,7 +3,7 @@ import time
 import numpy as np
 
 
-def benchmark_functions (funcs: list, *args: tuple, num_samples: int=10, **kwargs: dict) -> dict:
+def benchmark_functions (funcs: list, *args: tuple, num_samples: int=10, skipOne=False, **kwargs: dict) -> dict:
     """
     Benchmark multiple functions by running them num_samples times and recording their execution times. For the sake of compiled warp kernels, we run each function once that is not timed.
 
@@ -16,14 +16,14 @@ def benchmark_functions (funcs: list, *args: tuple, num_samples: int=10, **kwarg
         dict: A dictionary mapping function names to lists of execution times.
     """
     times = {f.__name__: [] for f in funcs}
-    for i in range(num_samples + 1):
+    for i in range(num_samples + int(skipOne)):
         results = {f.__name__: [] for f in funcs}
         for f in funcs:
             start_time = time.time()
             res = f(*args, **kwargs)
             end_time = time.time()
 
-            if i > 0:
+            if not skipOne or i > 0:
                 times[f.__name__].append(end_time - start_time)
                 results[f.__name__].append(res)
 

--- a/src/vbd_solver.py
+++ b/src/vbd_solver.py
@@ -563,7 +563,7 @@ class VBDSolver:
                 wp.synchronize_device(self.device)
                 wp.launch(
                     accumulate_grad_hess,
-                    dim=[n_vertices_per_color],
+                    dim=[n_vertices_per_color, self.adj_v2e.shape[1]],
                     inputs=[
                         new_positions, self.old_positions, self.old_velocities, 
                         self.inv_Dm, self.dDs_dx, 
@@ -576,17 +576,18 @@ class VBDSolver:
                 )
                 wp.launch_tiled(
                     solve_grad_hess,
-                    dim=n_vertices,
+                    dim=n_vertices_per_color,
                     block_dim=64,
                     inputs=[gradients, hessians, self.active_mask, self.color_groups[c]],
                     outputs=[dxs]
                 )
                 wp.launch(
                     add_dx,
-                    dim=n_vertices,
+                    dim=n_vertices_per_color,
                     inputs=[new_positions, dxs, self.active_mask, self.color_groups[c]],
                     outputs=[new_positions]
                 )
+                # breakpoint()
 
             hist["dx"].append(abs(dxs.numpy()).mean())
             # hist["grad"].append(abs(grads.numpy()).mean())

--- a/src/vbd_solver.py
+++ b/src/vbd_solver.py
@@ -526,6 +526,8 @@ class VBDSolver:
         n_colors = self.color_groups.shape[0]
         n_vertices_per_color = self.color_groups.shape[1]
 
+        assert MAX_ELEMENTS_PER_VERTEX >= self.adj_v2e.shape[1], "MAX_ELEMENTS_PER_VERTEX is smaller than the maximum number of incident elements per vertex. Increase this constant and recompile."
+
         if dx_tol is None:
             dx_tol = self.dx_tol
 


### PR DESCRIPTION
Using Warp Tiling for solving the hessian inversion instead of wp.inverse. Better runtimes at lower resolution meshes, but at larger meshes scales similarly to before.